### PR TITLE
Use deploy key instead of personal access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ jobs:
           badgedir: ${{ steps.run-conformance.outputs.badgedir }}
           repository: ${{ github.repository_owner }}/conformance
           upload-default-branch: true
-          token: ${{ secrets.CONFORMANCE_TOKEN }}
+          ssh-key: ${{ secrets.CONFORMANCE_KEY }}
 ```
 
 ## Input parameters
@@ -40,6 +40,6 @@ jobs:
 | `badgedir` | true | - | full path to the directory that stores conformance badges |
 | `repository` | true | - | repository (in the form of `owner/repo`) to store badges |
 | `upload-default-branch` | false | false | whether uploading the result of HEAD in the default branch |
-| `token` | true | - | token to commit the repository specified in the `repository` field |
+| `ssh-key` | true | - | ssh key to commit the repository specified in the `repository` field. See [deploy keys](https://docs.github.com/en/developers/overview/managing-deploy-keys#deploy-keys) for details |
 
 This action has no output parameters.

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     required: false
     default: false
   ssh-key:
-    description: 'deploy key to commit the repository specified in the `repository` field. Either `token` or `ssh-key` is needed'
+    description: 'deploy key to commit the repository specified in the `repository` field
     required: true
 runs:
   using: 'composite'

--- a/action.yml
+++ b/action.yml
@@ -23,8 +23,8 @@ inputs:
     description: 'whether uploading the result of HEAD in the default branch'
     required: false
     default: false
-  token:
-    description: 'token to commit the repository specified in the `repository` field'
+  ssh-key:
+    description: 'deploy key to commit the repository specified in the `repository` field. Either `token` or `ssh-key` is needed'
     required: true
 runs:
   using: 'composite'
@@ -33,7 +33,7 @@ runs:
       with:
         repository: ${{ inputs.repository }}
         path: conformance
-        token: ${{ inputs.token }}
+        ssh-key: ${{ inputs.ssh-key }}
     - name: Save badges
       working-directory: conformance
       shell: bash


### PR DESCRIPTION
Currently `upload-conformance-badges` needs a personal access token (PAT) to upload the conformance badges but it enables to read and write all the repositories in the organization or the user.
This request fixes this issue by using repository deploy key instead of PAT.

Other options are listed in the following link:
- https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#considering-cross-repository-access